### PR TITLE
fix(overlays): enforce gatekeeper native validation off in all overlays

### DIFF
--- a/overlays/az-1/patches/platform-core.yaml
+++ b/overlays/az-1/patches/platform-core.yaml
@@ -11,6 +11,8 @@ spec:
         global:
           clusterName: az-1
         bootstrap:
+          gatekeeper:
+            enableK8sNativeValidation: false
           nats:
             enabled: true
             gateway:

--- a/overlays/az-2/patches/platform-core.yaml
+++ b/overlays/az-2/patches/platform-core.yaml
@@ -11,6 +11,8 @@ spec:
         global:
           clusterName: az-2
         bootstrap:
+          gatekeeper:
+            enableK8sNativeValidation: false
           nats:
             enabled: true
             gateway:

--- a/overlays/cace-1-dev/patches/platform-core.yaml
+++ b/overlays/cace-1-dev/patches/platform-core.yaml
@@ -12,6 +12,7 @@ spec:
           clusterName: cace-1-dev
         bootstrap:
           gatekeeper:
+            enableK8sNativeValidation: false
             policies:
               excludedNamespaces:
                 - kube-system

--- a/overlays/cace-2-dev/patches/platform-core.yaml
+++ b/overlays/cace-2-dev/patches/platform-core.yaml
@@ -10,6 +10,8 @@ spec:
         global:
           clusterName: cace-2-dev
         bootstrap:
+          gatekeeper:
+            enableK8sNativeValidation: false
           monitoring:
             enabled: true
           nats:


### PR DESCRIPTION
## Why
Even with base values defaulting native validation off, overlays can accidentally override behavior later. This PR hardens overlays so Gatekeeper bootstrap remains safe and deterministic.

## What changed
Added explicit overlay value in all cluster platform-core patches:
- `bootstrap.gatekeeper.enableK8sNativeValidation: false`

Files:
- `overlays/az-1/patches/platform-core.yaml`
- `overlays/az-2/patches/platform-core.yaml`
- `overlays/cace-1-dev/patches/platform-core.yaml`
- `overlays/cace-2-dev/patches/platform-core.yaml`

## Validation
- `kubectl kustomize` succeeds for:
  - `overlays/az-1`
  - `overlays/az-2`
  - `overlays/cace-1-dev`
- `overlays/cace-2-dev` currently fails due to pre-existing missing file:
  - `patches/crossplane-identity.yaml` not found
  - (unrelated to this PR)

## Rollback
- Revert this PR commit to remove explicit overlay guardrails.
