### PR TITLE
feat(cace-1-dev): enable hermes-sre read-only ServiceAccount

### DIFF
--- a/overlays/cace-1-dev/patches/platform-core.yaml
+++ b/overlays/cace-1-dev/patches/platform-core.yaml
@@ -21,6 +21,8 @@ spec:
                 - argocd
                 - azure-arc
                 - it-gitops-enterprise-prd
+          hermesSre:
+            enabled: true
           monitoring:
             enabled: false
           argocd:


### PR DESCRIPTION
## Summary

Activates `bootstrap.hermesSre.enabled: true` on the `cace-1-dev` overlay, now that `DramisInfo/platform-helm#68` (the read-only ClusterRole/ServiceAccount) has merged and synced clean (`platform-core` Application is `Synced`/`Healthy` at that revision).

## What this does on merge

ArgoCD will create:
- Namespace `hermes-sre`
- ServiceAccount `hermes-sre-readonly`
- A long-lived ServiceAccount token Secret
- A read-only ClusterRole (`get`/`list`/`watch` on pods, pod logs, events, nodes, workloads, metrics, ArgoCD/Crossplane status — no `secrets`, no write/delete/exec) + ClusterRoleBinding

No other cluster state changes.

## Next step after merge

Once synced, I'll pull the ServiceAccount's token from the `hermes-sre-readonly-token` Secret to build a standalone scoped kubeconfig for a new dedicated Hermes profile.
