### PR TITLE
fix: remove invalid default release-type from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "packages": {
     ".": {
-      "release-type": "default",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true
     }


### PR DESCRIPTION
## Summary

The previous release-please setup used
`"release-type": "default"` in
`release-please-config.json`, but `default` is not a
valid release-please release type. As a result, the
release-please Action failed on every push to main
with the error:

  ```
  release-please failed: core (DramisInfo/platform-tools):
  Unknown release type: default
  ```

This PR removes the `release-type` field so release-please
uses its built-in default behavior, which is the right
thing for repos that have no versionable artifact (no
Chart.yaml, package.json, etc.).

## What this PR does

- Removes the `"release-type": "default"` line from
  `release-please-config.json`.
- Keeps the `bump-minor-pre-major` and
  `bump-patch-for-minor-pre-major` settings (these
  apply to all versioning strategies).

## What this PR does NOT do

- Does not change `.release-please-manifest.json`.
- Does not change the workflow file
  (`.github/workflows/release-please.yml`).
- Does not commit or push to main.