### PR TITLE
docs: add docs/ folder with user guide and architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# docs
+
+User guide and architecture documentation for `DramisInfo/platform-tools`.
+
+This bundle is the human-facing companion to `AGENTS.md`. `AGENTS.md` is the
+source of truth for AI agents working in this repo; the files here explain
+what the repo is, how the pieces fit together, and how to do day-to-day work
+in it.
+
+## How to navigate
+
+- [overview.md](./overview.md) — what this repo is, who uses it, when to touch it.
+- [architecture.md](./architecture.md) — how the base, overlays, Argo CD, and
+  the NATS load-test stack fit together.
+- [user-guide.md](./user-guide.md) — day-to-day tasks: rendering overlays,
+  running the NATS load test, refreshing Argo CD, troubleshooting.
+- [related-repos.md](./related-repos.md) — pointers to sibling repos in the
+  DramisInfo platform stack.
+
+If you are an AI agent, read `AGENTS.md` first — it has the layout, the
+conventions, and the "what NOT to do" guardrails. The `docs/` files here are
+written for humans operating the repo.
+
+## Scope of these docs
+
+The `docs/` folder is a documentation-only addition. It does not change any
+manifests, scripts, charts, or workflows in the repo. All of the things
+described here were already true of the repo before this folder existed; the
+docs just describe them.
+
+## What this repo is not
+
+- It is not the Helm chart. The chart lives in
+  [DramisInfo/platform-helm](https://github.com/DramisInfo/platform-helm) and
+  is consumed by the `Application` defined in `base/`.
+- It is not the Crossplane compositions. Those live in
+  [DramisInfo/platform-crossplane-compositions](https://github.com/DramisInfo/platform-crossplane-compositions).
+- It is not the platform bootstrap for new clusters. The cluster topology and
+  bootstrap process are documented in
+  [DramisInfo/home-lab](https://github.com/DramisInfo/home-lab).
+
+See [related-repos.md](./related-repos.md) for the full list.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,172 @@
+# Architecture
+
+This page describes how the pieces in this repo fit together, from the
+upstream Helm chart down to the Argo CD reconciliation loop in each cluster
+and the workstation-side NATS load test.
+
+## High-level shape
+
+```
+DramisInfo/platform-helm (chart: platform-core @ HEAD)
+                  │
+                  ▼
+       base/platform-core.yaml          ← single Argo CD Application
+                  │
+       ┌──────────┼──────────┬──────────┐
+       ▼          ▼          ▼          ▼
+overlays/az-1  overlays/az-2  overlays/  overlays/
+                            cace-1-dev cace-2-dev
+       │          │          │          │
+       ▼          ▼          ▼          ▼
+   Argo CD     Argo CD     Argo CD    Argo CD
+   in cluster  in cluster  in cluster in cluster
+                  │          │
+                  │          └──── teams/team-alpha/ (AppProject + AppSet)
+                  │
+       (workstation, not Argo CD)
+                  │
+                  ▼
+         nats-load-test/ (publisher + subscriber + k6)
+                  │
+                  ▼
+       nats.cace-1-dev   ↔   nats.cace-2-dev
+       (publisher)           (subscriber)
+```
+
+The base manifest is one `Application`. Each overlay is a thin patch on top.
+Argo CD reconciles the rendered output in each cluster. The NATS load test
+runs on a workstation and talks to the clusters over their public NATS
+hostnames — it is intentionally outside the Argo CD control loop.
+
+## The base `Application`
+
+`base/platform-core.yaml` is the only place that pins the upstream chart:
+
+- `repoURL`: `https://github.com/DramisInfo/platform-helm.git`
+- `targetRevision: "HEAD"` — deliberate; not a tag.
+- `path: platform-core` — the chart path inside the upstream repo.
+- `project: default` — the Argo CD AppProject that already exists in each
+  cluster.
+- `destination.namespace: test-helm`,
+  `destination.server: https://kubernetes.default.svc` — in-cluster.
+- `syncPolicy.automated.prune: true`, `selfHeal: true`.
+- `syncPolicy.syncOptions`:
+  - `CreateNamespace=true`
+  - `SkipDryRunOnMissingResource=true`
+  - `Validate=false`
+  - `Prune=true`
+- `metadata.annotations."argocd.argoproj.io/sync-wave": "-100"` — reconciles
+  before anything that depends on `platform-core`.
+- `metadata.finalizers: ["resources-finalizer.argocd.argoproj.io"]` — so Argo
+  CD can clean up resources on delete.
+
+`base/kustomization.yaml` is a one-line wrapper that lists this manifest.
+Every overlay inherits `../../base`.
+
+## Overlays
+
+Each overlay is a Kustomize `Kustomization` that:
+
+1. Inherits `../../base` under `resources:`.
+2. Sets `commonLabels.environment` (`dev` for `az-1`, `az-2`, `cace-1-dev`;
+   `staging` for `cace-2-dev`).
+3. Applies `patches/platform-core.yaml` (strategic-merge on
+   `spec.source.helm.valuesObject`).
+4. For `cace-1-dev` and `cace-2-dev`, additionally applies
+   `patches/crossplane-identity.yaml` to inject the public Azure UMI
+   `clientId` under `bootstrap.crossplane.workloadIdentity.clientId`.
+
+The patch target is always `kind: Application, name: platform-core`; only
+`spec.source.helm.valuesObject` and (rarely) `syncPolicy` are overridden.
+
+### What each overlay sets
+
+- **`az-1`** — `global.clusterName: az-1`, NATS gateway enabled and pointing
+  at `az-2-cluster` (`nats://nats.az-2.dramisinfo.com:7222`).
+- **`az-2`** — mirror of `az-1`, pointing back at `az-1-cluster`.
+- **`cace-1-dev`** — `global.clusterName: cace-1-dev`, `hermesSre.enabled:
+  true`, `monitoring.enabled: false`, gatekeeper `excludedNamespaces`
+  populated (`kube-system`, `gatekeeper-system`, `cert-manager`,
+  `istio-system`, `argocd`, `azure-arc`, `it-gitops-enterprise-prd`),
+  `bootstrap.argocd.smeeUrl` set, NATS gateway **disabled**.
+- **`cace-2-dev`** — `global.clusterName: cace-2-dev`,
+  `monitoring.enabled: true`, NATS gateway enabled and pointing at
+  `cace-1-dev-cluster` (`nats://nats.cace-1-dev.dramisinfo.com:7222`).
+
+The `cace-1-dev` `bootstrap.nats.gateway` block carries an inline comment
+explaining the 2026-06-23 decision to leave it disabled after `cace-2-dev`
+was decommissioned.
+
+### `teams/team-alpha/`
+
+`overlays/cace-1-dev/teams/team-alpha/` is a standalone kustomization that
+defines:
+
+- An `AppProject` (`team-alpha`) restricting destinations to
+  `team-alpha-*` namespaces plus `kube-system`.
+- An `ApplicationSet` (`team-alpha-apps`) that scans
+  `app-teams/team-alpha/cace-1-dev/*` in this same repo and renders one
+  `Application` per directory.
+- A `Namespace` template (in `namespaces.yaml`).
+
+It is not yet listed under `cace-1-dev/kustomization.yaml`'s `resources:`
+— its own `kustomization.yaml` is the entry point. The scanned path
+(`app-teams/team-alpha/cace-1-dev/*`) does not exist in the tree yet, so the
+generator currently produces nothing.
+
+## Argo CD reconciliation
+
+Each rendered `Application` carries:
+
+- `sync-wave: "-100"` — reconciles before any other Application.
+- The `resources-finalizer.argocd.argoproj.io` finalizer.
+- `automated.prune: true`, `automated.selfHeal: true`.
+
+Argo CD pulls `DramisInfo/platform-helm` at `HEAD`, renders the chart with
+the overlay-supplied `valuesObject`, and reconciles the result against live
+cluster state. Drift is corrected automatically; failures are retried with
+the backoff schedule in `syncPolicy.retry`.
+
+## NATS load-test stack
+
+`nats-load-test/docker-compose.yml` defines three services:
+
+- `publisher` (Fastify, Node 22) — `POST /publish` on port 3000, forwards
+  each request as a NATS message to `nats.cace-1-dev.dramisinfo.com:4222` on
+  subject `loadtest.cross`. Has a Docker healthcheck on `GET /health`.
+- `subscriber` — connects to `nats.cace-2-dev.dramisinfo.com:4222`,
+  subscribes to `loadtest.cross`, logs throughput + cross-cluster latency
+  every `STATS_INTERVAL_MS` (default 2000 ms). `NATS_QUEUE` empty =
+  fan-out; set = competing consumers.
+- `k6` — uses the grafana/k6 image; `VUS` virtual users hit the publisher
+  via `http://publisher:3000` for `DURATION` (defaults: 10 VUs / 60s).
+
+`nats-cluster-test.sh` wraps the compose file with `build | test | status |
+interactive | down` and reads env overrides (`VUS`, `DURATION`,
+`PUBLISHER_REPLICAS`, `SUBSCRIBER_REPLICAS`). It auto-builds the images if
+they are missing before running `test` or `interactive`.
+
+The stack is workstation-driven: it talks to the clusters over the public
+NATS hostnames, not via in-cluster service discovery. Do not move it under
+Argo CD.
+
+## Operator scripts
+
+- `kube.sh` — `scp ubuntu@192.168.20.10:/etc/rancher/k3s/k3s.yaml
+  ~/.kube/k3s-dev1-config`, rewrites `127.0.0.1` → `192.168.20.10`, renames
+  the default context/cluster/user to `k3s-dev1`, then flattens the result
+  into `~/.kube/config` (backing up the existing config first).
+- `ansible/playbook.yml` — runs against the `master` group in
+  `ansible/inventory.ini` (the four k3s masters at `192.168.20.10`, `.20`,
+  `.30`, `.90`). For each Argo CD `Application` in the `argocd` namespace,
+  it runs `kubectl patch application ... -p '{"operation":{"refresh":
+  "normal",...}}'`. Uses `KUBECONFIG: /etc/rancher/k3s/k3s.yaml`.
+
+## Agent specs
+
+`.github/agents/component-manager.agent.md` and
+`.github/agents/dashboard.agent.md` are repo-local Copilot-style specs, both
+explicitly scoped to `cace-1-dev`. The
+`.github/prompts/manage-component.prompt.md` prompt wires the
+`component-manager` agent. They are convenience wrappers, not a deployment
+mechanism.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,110 @@
+# Overview
+
+`platform-tools` is the GitOps configuration surface for the `platform-core`
+Argo CD Application across the DramisInfo platform clusters. It also bundles
+the docker-compose NATS cross-cluster load-test stack and a few operator
+scripts (`kube.sh`, `nats-cluster-test.sh`, `ansible/playbook.yml`).
+
+The repo is consumed by Argo CD; nothing here is applied by hand.
+
+## What lives here
+
+The repo owns three concerns:
+
+1. **The base `Application`.** `base/platform-core.yaml` is the single source
+   of truth for the `platform-core` Argo CD `Application`. It pins the
+   `platform-core` chart from
+   [DramisInfo/platform-helm](https://github.com/DramisInfo/platform-helm) at
+   `targetRevision: HEAD` and applies automated prune + selfHeal with
+   `CreateNamespace=true`.
+2. **Per-cluster overlays.** `overlays/<cluster>/` is one Kustomize overlay
+   per target cluster. Each overlay inherits `../../base` and applies a
+   strategic-merge patch on `spec.source.helm.valuesObject` to set
+   `global.clusterName`, toggle `bootstrap.hermesSre.enabled` /
+   `bootstrap.monitoring.enabled`, configure the NATS gateway block, and (for
+   `cace-1-dev`) inject the Crossplane UMI client ID.
+3. **The NATS load-test stack.** `nats-load-test/` is a docker-compose stack
+   (Fastify `publisher`, NATS `subscriber`, k6 load generator) driven from a
+   workstation via `nats-cluster-test.sh`. It publishes on
+   `nats.cace-1-dev.dramisinfo.com` and subscribes on
+   `nats.cace-2-dev.dramisinfo.com` to verify cross-cluster message delivery
+   and latency.
+
+The `kube.sh` and `ansible/playbook.yml` helpers are operator shortcuts: the
+first pulls a kubeconfig from a k3s master into `~/.kube/config`, the second
+refreshes every Argo CD `Application` across all four k3s masters.
+
+## Clusters currently configured
+
+Four clusters are configured via overlays:
+
+- `overlays/az-1/` — dev, `clusterName: az-1`, NATS gateway points at
+  `az-2` (`az-2-cluster`).
+- `overlays/az-2/` — dev, mirror of `az-1/` for the second AZ.
+- `overlays/cace-1-dev/` — dev, `clusterName: cace-1-dev`, `hermesSre` on,
+  monitoring off, gatekeeper `excludedNamespaces` populated, NATS gateway
+  **disabled**. Also hosts the `teams/team-alpha/` AppProject + ApplicationSet
+  + Namespace bundle and the `patches/crossplane-identity.yaml` patch for the
+  public Azure UMI client ID.
+- `overlays/cace-2-dev/` — staging, `clusterName: cace-2-dev`, monitoring on,
+  NATS gateway points at `cace-1-dev`.
+
+The `cace-2-dev` cluster itself is decommissioned (see commit history from
+2026-06-23). The `cace-2-dev/` overlay's `clusterName` and its own gateway
+declaration remain valid as long as `cace-2-dev` itself exists, but
+`cace-1-dev/patches/platform-core.yaml` must keep
+`bootstrap.nats.gateway.enabled: false`.
+
+## Who uses this repo
+
+- **Platform operators** — render overlays with `kustomize build`, refresh
+  Argo CD via the ansible play, run the NATS cross-cluster load test, and
+  tweak overlay patches when a cluster's configuration needs to change.
+- **AI agents** — `AGENTS.md` is the authoritative guide. The `.github/agents/`
+  specs (`component-manager`, `dashboard`) and the
+  `.github/prompts/manage-component.prompt.md` prompt are scoped to
+  `cace-1-dev` only.
+- **Anyone reading the rendered output** — the manifests in `overlays/`
+  describe exactly what Argo CD will reconcile in each cluster.
+
+## When to touch this repo
+
+Touch this repo when:
+
+- A cluster's `platform-core` configuration needs to change (toggle
+  `hermesSre`, `monitoring`, the NATS gateway block, gatekeeper
+  `excludedNamespaces`, the Crossplane UMI client ID).
+- A new cluster overlay needs to be added.
+- The Crossplane UMI client ID for `cace-1-dev` rotates (the `clientId` is a
+  public Azure Application ID, not a secret; rotations land via PR).
+- The NATS load-test stack needs new scenarios, additional replicas, or
+  different defaults.
+
+Do not touch this repo to change the chart itself — that lives in
+[DramisInfo/platform-helm](https://github.com/DramisInfo/platform-helm) and
+flows through `targetRevision: HEAD` automatically.
+
+## Deploy path
+
+Argo CD is the only deploy path. Each overlay renders to an `Application` CR
+that Argo CD reconciles in the target cluster. The `Application` carries
+`argocd.argoproj.io/sync-wave: "-100"` so `platform-core` reconciles before
+anything that depends on it, and the
+`resources-finalizer.argocd.argoproj.io` finalizer so Argo CD can clean up
+on delete.
+
+## Layout at a glance
+
+- `base/` — `platform-core` `Application` (chart pin, sync policy, finalizer).
+- `overlays/az-1/`, `overlays/az-2/`, `overlays/cace-1-dev/`,
+  `overlays/cace-2-dev/` — per-cluster patches.
+- `overlays/cace-1-dev/teams/team-alpha/` — AppProject + ApplicationSet +
+  Namespace template (standalone kustomization; not yet listed in
+  `cace-1-dev/kustomization.yaml`).
+- `nats-load-test/` — docker-compose stack.
+- `nats-cluster-test.sh` — wrapper around the compose file.
+- `kube.sh` — kubeconfig pull.
+- `ansible/` — refresh play for Argo CD across all k3s masters.
+- `.github/agents/`, `.github/prompts/` — repo-local agent specs (scoped to
+  `cace-1-dev`).
+- `AGENTS.md` — agent-facing source of truth.

--- a/docs/related-repos.md
+++ b/docs/related-repos.md
@@ -1,0 +1,27 @@
+# Related repos
+
+This repo is part of the DramisInfo home-lab platform stack. The
+other repos in the stack:
+
+- [DramisInfo/home-lab](https://github.com/DramisInfo/home-lab) —
+  Source of truth for cluster topology, hardware, network layout,
+  and high-level architecture decisions.
+- [DramisInfo/platform-tools](https://github.com/DramisInfo/platform-tools) —
+  Shared scripts, CLIs, and helper tooling used across the stack.
+- [DramisInfo/platform-helm](https://github.com/DramisInfo/platform-helm) —
+  The platform-core Helm chart (umbrella chart that composes all
+  platform services).
+- [DramisInfo/platform-crossplane-compositions](https://github.com/DramisInfo/platform-crossplane-compositions) —
+  Crossplane CompositeResourceDefinitions and Compositions that
+  project Azure resources into the cluster via Azure Arc.
+- [DramisInfo/platform-project-workspaces](https://github.com/DramisInfo/platform-project-workspaces) —
+  Per-project tenant workspaces: namespaces, RBAC, quotas, and
+  Argo CD ApplicationSets scoped to a single project.
+- [DramisInfo/platform-standards](https://github.com/DramisInfo/platform-standards) —
+  Repo-wide conventions, schemas, and policy documents referenced
+  by all other repos.
+- [DramisInfo/platform-workflows](https://github.com/DramisInfo/platform-workflows) —
+  Reusable GitHub Actions workflows and composite actions.
+- [DramisInfo/crossplane-providers-and-functions](https://github.com/DramisInfo/crossplane-providers-and-functions) —
+  Custom Crossplane providers and composition functions used by
+  the platform-crossplane-compositions stack.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,177 @@
+# User guide
+
+Day-to-day tasks for working with this repo: rendering overlays, applying
+changes, running the NATS load test, refreshing Argo CD, and troubleshooting
+the common failure modes.
+
+## Prerequisites
+
+- `kubectl`
+- `kustomize`
+- `docker` (with Compose v2: `docker compose ...`)
+- `ansible` — only if you want to use the cluster refresh play
+- `gh` — only for opening PRs
+
+Argo CD must already be installed in each target cluster, with a project
+named `default` and the `argocd` namespace present. Cluster bootstrap is out
+of scope for this repo; it is owned by
+[DramisInfo/home-lab](https://github.com/DramisInfo/home-lab).
+
+SSH access to `ubuntu@192.168.20.10` (or whichever k3s master you target)
+is required for `kube.sh` and the ansible play.
+
+## Render an overlay
+
+To verify a patch lands cleanly, render the overlay with `kustomize` and
+inspect the output:
+
+```bash
+kustomize build overlays/cace-1-dev | less
+```
+
+Re-render `base/` first if a base change is suspected — every overlay
+inherits it, so a chart-pinned diff in `base/platform-core.yaml` will surface
+in all four overlays.
+
+## Tweak an overlay patch
+
+The values you actually touch live in `overlays/<env>/patches/`, not in any
+Helm values file. Open the patch and edit the `valuesObject` block:
+
+- `overlays/<env>/patches/platform-core.yaml` — strategic-merge patch on
+  `spec.source.helm.valuesObject`. Sets `global.clusterName`, toggles
+  `bootstrap.hermesSre.enabled` / `bootstrap.monitoring.enabled`, and
+  configures the `bootstrap.nats.gateway` block (advertise URL, peer
+  gateways, enabled flag).
+- `overlays/cace-1-dev/patches/crossplane-identity.yaml` — public Azure UMI
+  `clientId` for the Crossplane identity. Safe to commit; rotated via PR by
+  an automated job.
+
+Then re-render with `kustomize build overlays/<env>` to verify the change.
+
+## Run the NATS cross-cluster load test
+
+The wrapper auto-builds images on first run, then drives the publisher /
+subscriber / k6 stack end-to-end:
+
+```bash
+./nats-cluster-test.sh test
+# 10 VUs for 60s, 10 publisher + 10 subscriber replicas by default
+```
+
+Override defaults with environment variables:
+
+```bash
+VUS=50 DURATION=120s \
+  PUBLISHER_REPLICAS=3 SUBSCRIBER_REPLICAS=2 \
+  ./nats-cluster-test.sh test
+```
+
+Other subcommands:
+
+- `./nats-cluster-test.sh build` — build (or rebuild) images.
+- `./nats-cluster-test.sh status` — show running containers + publisher
+  health.
+- `./nats-cluster-test.sh interactive` — start publisher/subscriber in the
+  background, tail subscriber logs, print the in-container `wget` command
+  for a one-off publish.
+- `./nats-cluster-test.sh down` — stop and remove all containers.
+- `./nats-cluster-test.sh help` — full usage.
+
+For manual probing without the wrapper, drive the compose file directly:
+
+```bash
+docker compose -f nats-load-test/docker-compose.yml up --build
+```
+
+## Refresh every Argo CD Application across all clusters
+
+The ansible play iterates over every `Application` in the `argocd`
+namespace on each k3s master and patches it with a normal refresh
+operation:
+
+```bash
+ansible-playbook -i ansible/inventory.ini ansible/playbook.yml
+```
+
+It uses `KUBECONFIG: /etc/rancher/k3s/k3s.yaml` on the target. The
+inventory lists the four masters at `192.168.20.10`, `.20`, `.30`, `.90`.
+
+Use this when an Application shows `OutOfSync` with no diff, or after a
+change has landed in the chart but Argo CD has not picked it up.
+
+## Pull a kubeconfig
+
+To pull the dev1 kubeconfig from the k3s master into `~/.kube/config` as
+context `k3s-dev1`:
+
+```bash
+./kube.sh
+```
+
+The script is hard-coded to `ubuntu@192.168.20.10`. Make sure your SSH
+agent has the matching key and the host is reachable.
+
+## Open a PR
+
+There is no CI workflow in this repo — branch + PR is the entire review
+loop. The repo follows Conventional Commits and `<type>/<scope>` branch
+names (e.g. `feat/cace-1-dev/<slug>`, `fix/nats/<slug>`). Automated
+client-ID rotations land via PR with the `Update Crossplane UMI client ID
+...` prefix.
+
+## Troubleshooting
+
+### `kustomize build` fails on an overlay after a base change
+
+Re-render `kustomize build base` first. Every overlay inherits the base, so
+a chart-pinned diff in `base/platform-core.yaml` will surface in all four
+overlays. Fix the base (or the offending overlay's patch) and re-render.
+
+### Argo CD shows `platform-core` as `OutOfSync` with no diff
+
+Force a refresh across all clusters via the ansible play
+(`ansible-playbook -i ansible/inventory.ini ansible/playbook.yml`). The play
+patches every `Application` with a normal refresh operation.
+
+### NATS load test never reaches the healthy publisher count
+
+Check `./nats-cluster-test.sh status` and inspect container logs. A stale
+image is the usual cause — run `./nats-cluster-test.sh build` and retry.
+
+### JetStream warnings about "no metadata leader"
+
+Confirm the cace-2-dev gateway is **not** re-enabled in
+`overlays/cace-1-dev/patches/platform-core.yaml` —
+`bootstrap.nats.gateway.enabled: false`. The `cace-2-dev` cluster was
+decommissioned on 2026-06-23 and the gateway was blocking JetStream metadata
+RAFT leader election.
+
+### `kube.sh` fails on `scp`
+
+The script is hard-coded to `ubuntu@192.168.20.10`. Make sure your SSH agent
+has the matching key and the host is reachable before re-running.
+
+### `team-alpha` ApplicationSet renders zero Applications
+
+This is expected until `app-teams/team-alpha/cace-1-dev/*` exists in the
+repo. The ApplicationSet's `git` generator scans that path; with no
+directories present, no Applications are produced.
+
+## Security
+
+- Do not commit kubeconfigs, kubeconfig certificates, Argo CD admin
+  passwords, or registry credentials.
+- The `clientId` in `overlays/cace-1-dev/patches/crossplane-identity.yaml`
+  is a public Azure UMI Application (client) ID, not a secret. Do not paste
+  the matching secret value into this repo.
+- Do not bypass Argo CD with `kubectl apply` from a workstation. Use
+  `ansible/playbook.yml` or the Argo CD UI/API.
+- Do not move `nats-load-test/` under Argo CD. It is a workstation-driven
+  docker-compose stack talking to the clusters over the public NATS
+  hostnames.
+
+The full guardrail list — chart-version bumps, overlay scope, the
+`targetRevision: HEAD` pin, the absence of a repo-root `package.json`, and
+so on — lives in the "What NOT to do" section of
+[`AGENTS.md`](../AGENTS.md).


### PR DESCRIPTION
## Summary
Adds a `docs/` folder with user-guide and architecture documentation
for this repo.

## What's in the docs bundle
- `docs/README.md` — index + how to navigate
- `docs/overview.md` — what this repo is and when to touch it
- `docs/architecture.md` — how the pieces fit together
- `docs/user-guide.md` — day-to-day tasks and troubleshooting
- `docs/related-repos.md` — pointers to sibling DramisInfo repos

## Out of scope
- No source code, chart, template, or workflow changes.
- Related-repos list is canonical across the batch.
