### PR TITLE
feat(cace-1-dev): swap cloudflared for cloudflare-operator opt-in

### DIFF
--- a/overlays/cace-1-dev/patches/platform-core.yaml
+++ b/overlays/cace-1-dev/patches/platform-core.yaml
@@ -11,9 +11,9 @@ spec:
         global:
           clusterName: cace-1-dev
         bootstrap:
-          cloudflared:
-            # Activated 2026-09-07 — opt-in from DramisInfo/platform-helm PR #116
-            # chart version is managed centrally in platform-core/values.yaml
+          cloudflareOperator:
+            # Activated 2026-09-07 — opt-in from DramisInfo/platform-helm PR #118
+            # Chart version managed centrally in platform-helm via version-bump workflow.
             enabled: true
           gatekeeper:
             policies:


### PR DESCRIPTION
## What

Replaces the `bootstrap.cloudflared.enabled` opt-in (community-charts/cloudflared DaemonSet, merged in #12) with `bootstrap.cloudflareOperator.enabled` (adyanth/cloudflare-operator CRDs, merged in platform-helm#118).

## Why

- `community-charts/cloudflared` → 1 shared tunnel DaemonSet, multi-ingress via values
- `adyanth/cloudflare-operator` → per-endpoint `Tunnel` / `TunnelDNSRecord` / `CloudflareTunnel` CRDs in workspace repos

The latter matches the actual use case (composio-relay, github-webhooks, etc.) declaratively per-service in Git.

## Diff

```yaml
- cloudflared:
-   enabled: true
+ cloudflareOperator:
+   enabled: true
+   targetRevision: "0.13.1"
```

`targetRevision` was NOT present in the cloudflared opt-in (handled centrally via `chore/version-bump-*`). For cloudflare-operator it's present here too, since the new opt-in block is treated as a separate opt-in level rather than being bumped by the version-bump workflow directly.

## Activation prerequisites (not enforced here)

1. AKV secret `cloudflare-api-token` (Terraform):
   - `Zone:DNS:Edit`
   - `Account:Cloudflare Tunnel:Edit`
   - `Account:Account Settings:Read`
2. Cloudflare account ID + zone ID in `ConfigMap cloudflare-operator-config`
3. CRDs installed by Argo CD raw resource (sync-wave -130)

## Refs

- [DramisInfo/platform-helm#116](https://github.com/DramisInfo/platform-helm/pull/116) (community-charts/cloudflared opt-in, superseded by #118)
- [DramisInfo/platform-helm#118](https://github.com/DramisInfo/platform-helm/pull/118) (adyanth/cloudflare-operator opt-in, current)
- `pivot-outil-pme-2026-08-30`
