### PR TITLE
feat(cace-1-dev): set bootstrap.cloudflareOperator.accountId

### DIFF
--- a/overlays/cace-1-dev/patches/platform-core.yaml
+++ b/overlays/cace-1-dev/patches/platform-core.yaml
@@ -15,6 +15,11 @@ spec:
             # Activated 2026-09-07 — opt-in from DramisInfo/platform-helm PR #118
             # Chart version managed centrally in platform-helm via version-bump workflow.
             enabled: true
+            # Cloudflare account ID (public identifier, no AKV needed).
+            # Operator reads it via ConfigMap cloudflare-operator-account-id
+            # in cloudflare-operator-system, rendered by the multi-source
+            # Application (dysnix/raw) in platform-helm PR #122.
+            accountId: "383101591f0a369ea7f73b5bbc97dd36"
           gatekeeper:
             policies:
               excludedNamespaces:


### PR DESCRIPTION
## What

Adds `bootstrap.cloudflareOperator.accountId: "383101591f0a369ea7f73b5bbc97dd36"` to the cloudflare-operator opt-in block in `overlays/cace-1-dev/patches/platform-core.yaml`.

## Why

The cloudflare-operator Deployment (running in `cloudflare-operator-system`) reads `CLOUDFLARE_ACCOUNT_ID` from the ConfigMap `cloudflare-operator-account-id` (rendered by the multi-source Application added in platform-helm PR #122). Without this value in the overlay, the ConfigMap isn't created, and the operator can't authenticate Cloudflare API calls.

This is the **final wiring step** for the operator activation chain:

```
AKV (cloudflare-api-token)
  → ExternalSecret (platform-helm PR #120)
    → Secret cloudflare-secrets in cloudflare-operator-system
      → operator reads CLOUDFLARE_API_TOKEN

overlay cace-1-dev (this PR)
  → ConfigMap cloudflare-operator-account-id
    → operator reads CLOUDFLARE_ACCOUNT_ID
```

Both pieces need to be present for `Tunnel`, `ClusterTunnel`, `AccessTunnel`, `TunnelBinding` CRDs to reconcile against the Cloudflare API.

## Diff

```diff
          cloudflareOperator:
            enabled: true
+            accountId: "383101591f0a369ea7f73b5bbc97dd36"
```
