### PR TITLE
chore: disable cloudflareOperator (pivot Tailscale Operator)

### DIFF
--- a/overlays/cace-1-dev/patches/platform-core.yaml
+++ b/overlays/cace-1-dev/patches/platform-core.yaml
@@ -12,14 +12,9 @@ spec:
           clusterName: cace-1-dev
         bootstrap:
           cloudflareOperator:
-            # Activated 2026-09-07 — opt-in from DramisInfo/platform-helm PR #118
-            # Chart version managed centrally in platform-helm via version-bump workflow.
-            enabled: true
-            # Cloudflare account ID (public identifier, no AKV needed).
-            # Operator reads it via ConfigMap cloudflare-operator-account-id
-            # in cloudflare-operator-system, rendered by the multi-source
-            # Application (dysnix/raw) in platform-helm PR #122.
-            accountId: "383101591f0a369ea7f73b5bbc97dd36"
+            # Disabled 2026-09-07 — pivoting to Tailscale Operator + Funnel.
+            # Re-enable by flipping enabled: true.
+            enabled: false
           gatekeeper:
             policies:
               excludedNamespaces:


### PR DESCRIPTION
## Contexte

Pivot stratégique du lab cace-1-dev : on remplace l'opérateur Cloudflare par l'opérateur Tailscale pour l'exposition publique. Raisons :

- Le compte Cloudflare n'a pas de zone `dramisinfo.com` rattachée
- Cloudflare rejette les sous-domaines (API et UI)
- Tailscale Funnel offre une exposition publique immédiate via mesh Tailscale déjà déployé

## Changement

`bootstrap.cloudflareOperator.enabled: false` dans l'overlay cace-1-dev. Le chart reste opt-in dans platform-helm (réversible).

## À suivre

PR séparée pour ajouter `bootstrap.tailscaleOperator` opt-in dans platform-helm + activation dans platform-tools.

---

Cluster: cace-1-dev
Pattern: opt-in disable (réversible)