### PR TITLE
feat: activate tailscaleOperator opt-in on cace-1-dev

### DIFF
--- a/overlays/cace-1-dev/patches/platform-core.yaml
+++ b/overlays/cace-1-dev/patches/platform-core.yaml
@@ -15,6 +15,10 @@ spec:
             # Disabled 2026-09-07 — pivoting to Tailscale Operator + Funnel.
             # Re-enable by flipping enabled: true.
             enabled: false
+          tailscaleOperator:
+            # Activated 2026-09-07 — opt-in from DramisInfo/platform-helm PR #123.
+            # Chart version managed centrally in platform-helm via version-bump workflow.
+            enabled: true
           gatekeeper:
             policies:
               excludedNamespaces:


### PR DESCRIPTION
## Contexte

Pivot stratégique Cloudflare → Tailscale (PRs #16 platform-tools + #123 platform-helm mergés).

## Changement

`bootstrap.tailscaleOperator.enabled: true` dans l'overlay cace-1-dev.

## Pré-requis vérifié

- OAuth client créé dans Tailscale admin (scopes: device:write)
- AKV secrets pushés:
  - `akv-dramisinfo-shared/tailscale-operator-client-id`
  - `akv-dramisinfo-shared/tailscale-operator-client-secret`

## Résultat attendu

- Operator `tailscale-operator` déployé dans `tailscale-operator-system` (sync-wave -90)
- Secret `operator-oauth` créé et synchronisé depuis AKV via ExternalSecret
- CRDs `Connector`, `ProxyClass`, `Ingress` installées
- L'opérateur s'authentifie à Tailscale avec les credentials OAuth

## À suivre

PR séparée sur `it-integration-workspace` pour exposer `composio-relay` via Tailscale Funnel.